### PR TITLE
feat: added per-read anchor requirement to junction extract

### DIFF
--- a/src/cis-splice-effects/cis_splice_effects_identifier.cc
+++ b/src/cis-splice-effects/cis_splice_effects_identifier.cc
@@ -44,6 +44,8 @@ void CisSpliceEffectsIdentifier::usage(ostream& out) {
     out << "\t\t" << "-t STR\tTag used in bam to label strand. [XS]" << endl;
     out << "\t\t" << "-a INT\tMinimum anchor length. Junctions which satisfy a minimum \n"
         << "\t\t\t " << "anchor length on both sides are reported. [8]" << endl;
+    out << "\t\t" << "-A INT\tMinimum read anchor length. Reads which satisfy a minimum \n"
+        << "\t\t\t " << "anchor length on both sides 'support' a junction. [0]" << endl;
     out << "\t\t" << "-m INT\tMinimum intron length. [70]" << endl;
     out << "\t\t" << "-M INT\tMaximum intron length. [500000]" << endl;
     out << "\t\t" << "-f INT\tOnly use alignments where all flag bits set here are set. [0]" << endl;
@@ -116,7 +118,7 @@ void CisSpliceEffectsIdentifier::parse_options(int argc, char* argv[]) {
     optind = 1; //Reset before parsing again.
     stringstream help_ss;
     char c;
-    while((c = getopt(argc, argv, "o:w:v:j:e:Ei:ISht:s:a:m:M:f:F:q:b:C")) != -1) {
+    while((c = getopt(argc, argv, "o:w:v:j:e:Ei:ISht:s:a:A:m:M:f:F:q:b:C")) != -1) {
         switch(c) {
             case 'o':
                 output_file_ = string(optarg);
@@ -166,6 +168,9 @@ void CisSpliceEffectsIdentifier::parse_options(int argc, char* argv[]) {
                 break;
             case 'a':
                 min_anchor_length_ = atoi(optarg);
+                break;
+            case 'A':
+                min_read_anchor_length_ = atoi(optarg);
                 break;
             case 'm':
                 min_intron_length_ = atoi(optarg);
@@ -298,7 +303,8 @@ void CisSpliceEffectsIdentifier::identify() {
                 ref_to_pass = "NA";
             }
             JunctionsExtractor je1(bam_, variant_region, strandness_, 
-                    strand_tag_, min_anchor_length_, min_intron_length_, max_intron_length_, 
+                    strand_tag_, min_anchor_length_, min_read_anchor_length_, 
+                    min_intron_length_, max_intron_length_, 
                     filter_flags_, require_flags_, min_map_qual_, ref_to_pass);
             je1.identify_junctions_from_BAM();
             vector<Junction> junctions = je1.get_all_junctions();

--- a/src/cis-splice-effects/cis_splice_effects_identifier.h
+++ b/src/cis-splice-effects/cis_splice_effects_identifier.h
@@ -87,9 +87,10 @@ class CisSpliceEffectsIdentifier {
         //tag used in BAM to denote strand, default "XS"
         string strand_tag_;
         //Minimum anchor length for junctions
-        //Junctions need at least this many bp overlap
-        // on both ends.
+        //Junctions need at least this many bp overlap on both ends.
         uint32_t min_anchor_length_;
+        //Reads need at least this many bp overlap on both ends to support junction.
+        uint32_t min_read_anchor_length_;
         //Minimum length of an intron, i.e min junction width
         uint32_t min_intron_length_;
         //Maximum length of an intron, i.e max junction width
@@ -118,6 +119,7 @@ class CisSpliceEffectsIdentifier {
                                        strandness_(-1),
                                        strand_tag_("XS"),
                                        min_anchor_length_(8),
+                                       min_read_anchor_length_(0),
                                        min_intron_length_(70),
                                        max_intron_length_(500000),
                                        filter_flags_(0),

--- a/src/junctions/junctions_extractor.h
+++ b/src/junctions/junctions_extractor.h
@@ -153,9 +153,10 @@ class JunctionsExtractor {
         //Reference FASTA file
         string ref_;
         //Minimum anchor length for junctions
-        //Junctions need atleast this many bp overlap
-        // on both ends.
+        //Junctions need at least this many bp overlap on both ends.
         uint32_t min_anchor_length_;
+        //Reads need at least this many bp overlap to support a junction
+        uint32_t min_read_anchor_length_;
         //Minimum length of an intron, i.e min junction width
         uint32_t min_intron_length_;
         //Maximum length of an intron, i.e max junction width
@@ -190,6 +191,7 @@ class JunctionsExtractor {
         //Default constructor
         JunctionsExtractor() {
             min_anchor_length_ = 8;
+            min_read_anchor_length_ = 0;
             min_intron_length_ = 70;
             max_intron_length_ = 500000;
             filter_flags_ = 0;
@@ -211,6 +213,7 @@ class JunctionsExtractor {
                 int strandness1, 
                 string strand_tag1, 
                 uint32_t min_anchor_length1, 
+                uint32_t min_read_anchor_length1, 
                 uint32_t min_intron_length1, 
                 uint32_t max_intron_length1, 
                 uint16_t filter_flags, 
@@ -222,7 +225,8 @@ class JunctionsExtractor {
             strandness_(strandness1), 
             strand_tag_(strand_tag1), 
             min_anchor_length_(min_anchor_length1), 
-            min_intron_length_(min_anchor_length1), 
+            min_read_anchor_length_(min_read_anchor_length1), 
+            min_intron_length_(min_intron_length1), 
             max_intron_length_(max_intron_length1), 
             filter_flags_(filter_flags), 
             require_flags_(require_flags), 


### PR DESCRIPTION
 - closes #186, reads now only 'support' a junction if they have at least a given minimum anchor length, supplied with the '-A' flag (default 0)