### PR TITLE
fix: junctions extractor count overlapping read pairs once

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(TestHelper)
 
 #versioning stuff
 set (regtools_VERSION_MAJOR 1)
-set (regtools_VERSION_MINOR 0)
+set (regtools_VERSION_MINOR 1)
 set (regtools_VERSION_PATCH 0)
 
 configure_file (

--- a/src/junctions/junctions_extractor.h
+++ b/src/junctions/junctions_extractor.h
@@ -39,6 +39,8 @@ using namespace std;
 struct Junction : BED {
     //Number of reads supporting the junction
     unsigned int read_count;
+    //Reads supporting the junction
+    unordered_set<string> reads;
     //This is the start - max overhang
     CHRPOS thick_start;
     //This is the end + max overhang


### PR DESCRIPTION
 - closes #187, implemented by adding set of `reads` to `Junction`, and only incrementing `read_count` if read has not been seen yet
 - this commit should also increase RegTools speed by removing the barcode updating bottleneck caused by repeatedly copying the barcode map
 - updated regtools to v1.1.0